### PR TITLE
Enhancing About and making fixes

### DIFF
--- a/dialog-build.md
+++ b/dialog-build.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2017
-lastupdated: "2017-07-20"
+lastupdated: "2017-07-21"
 
 ---
 
@@ -723,9 +723,7 @@ Add slots to a dialog node to gather multiple pieces of information from a user 
 
 <iframe class="embed-responsive-item" id="youtubeplayer" type="text/html" width="640" height="390" src="https://www.youtube.com/embed/3unhxZUKZtk?rel=0" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen> </iframe>
 
-### How slots work
-
-You define a slot for each piece of information that you want to collect. Write a prompt that elicits the piece of the information from the user. The service cycles through the prompts for each slot to ask for the missing information, and saves the answers as they are provided.
+### Why add slots?
 
 Use slots to get the information you need before you can respond accurately to the user. For example, if users ask about operating hours, but the hours differ by store location, you could ask a follow-up question about which store location they plan to visit before you answer. You can then add response conditions that take the provided location information into account.
 
@@ -745,6 +743,20 @@ Slots make it possible for the bot to answer follow-up questions without having 
 
 Using slots produces a more natural dialog flow between the user and the bot, and is easier for you to manage than trying to collect the information by using many separate nodes.
 
+### How slots work
+
+Here's what you do:
+
+- Add a slot for each piece of information that you want to collect.
+- Write a prompt that elicits the piece of the information from the user.
+- Identify the type of information you want to extract from the user's answer.
+- Provide a name for the context variable in which the user's answer will be stored.
+- Provide a Found response that is displayed when the user answers the question as expected.
+- Provide a Not found response that is displayed when the user does not answer the question as expected. Here, you can clarify what you need.
+- Add a node-level response that indicates that you have received all the information you need.
+
+The service cycles through the prompts for each slot to ask for the missing information, and saves the answers as they are provided. It repeats the process until all of the slots are filled, meaning that all of the slot context variables contain valid values.
+
 #### Adding slots
 
 1.  Identify the units of information that you want to collect. For example, to order a pizza for someone, you might want to collect the following information:
@@ -753,7 +765,7 @@ Using slots produces a more natural dialog flow between the user and the bot, an
 1.  From the dialog node edit view, click **Customize**, and then select the **Slots** checkbox.
 1.  **Add a slot for each unit of required information**.
 
-    For each slot, specify what to look for in the user input, how to save the slot value when it is provided, and the text to display to users to prompt them to provide the information you need. You can also specify follow-up statements to display both when the value is provided and when it is not.
+    For each slot, specify what to look for in the user input, how to save the slot value when it is provided, and the text to display to users to prompt them to provide the information you need. You can also specify follow-up statements to display both when the value you want is provided and when it is not.
 
     <table>
     <tr>
@@ -815,6 +827,12 @@ Using slots produces a more natural dialog flow between the user and the bot, an
     This condition is triggered if the user provides input that matches the handler conditions at any time during the dialog node flow up until the final response is displayed.
 1.  **Add a node-level response**.
     The node response can summarize the information you collected. For example, "A `$size` pizza is scheduled for delivery at `$time`. Enjoy!"
+
+1.  **Add logic that resets the slot context variables**.
+    As you collect answers from the user per slot, they are saved in context variables. You can use the context variables to pass the information to another node or to an application or external service for use. However, after passing the information, you must set the context variables to null to reset the node so it can start collecting information again. You cannot null the context variables within the current node because the service will not exit the node until the required slots are filled. Instead, consider using one of the following methods:
+    - Add processing to the external application that nulls the variables.
+    - Add a child node that nulls the variables.
+    - Insert a parent node that nulls the variables, and then jumps to the node with slots.
 
 #### Tips for using slots
 
@@ -922,6 +940,10 @@ Consider these suggested approaches for handling common tasks.
     In addition, the service can recognize multiple entity types in a single user input. For example, when a user provides a currency, it is recognized as both a @sys-currency and @sys-number entity type. Do some testing in the "Try it out" pane to understand how the system will interpret different user inputs, and build logic into your conditions to prevent possible misinterpretations.
 
     **Tip**: In logic that is unique to the slots feature, when two entities are recognized in a single user input, the one with the larger span is used. For example, if the user enters *May 2*, even though the Conversation service recognizes both @sys-date (05022017) and @sys-number (2) entities in the text, only the entity with the longer span (@sys-date) is registered and applied to a slot, if applicable.
+
+- **Prevent a Found response from displaying when it's not needed**: If you specify Found responses for multiple slots, then if a user provides values for multiple slots at once, the Found response for at least one of the slots will be displayed. You probably want either the Found response for all of them or none of them to be returned. To prevent just one of the Found responses from being displayed, you can do one of the following things:
+    - Set the `all_slots_filled` property to true. This setting forces the service to exit the node, and skips over displaying the Found responses for any of the individual slots. Do not use this approach if you are including a confirmation slot or the confirmation slot will never be triggered.
+    - Add a condition to the Found response that prevents it from being displayed if more than one slot value is filled. For example, you can add `!($size && $time)` as the condition to prevent the response from being displayed if the $size and $time context variables are both provided.
 
 - **Handle requests to exit the process**: Add at least one node-level handler that can recognize it when a user wants to exit the node.
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -112,7 +112,7 @@ You can test your dialog at any time to verify the dialog. Let's test it now.
 
 ### Adding nodes to handle intents
 
-Now let's add nodes to handle our intents between the `conversation_start` node and the `anything_else` node.
+Now let's add nodes to handle our intents between the `Welcome` node and the `Anything else` node.
 
 1.  Click the More icon ![More options](images/kabob.png) on the **Welcome** node, and then select **Add node below**.
 1.  Type `#hello` in the **Enter a condition** field of this node. Then select the **#hello** option.

--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2017
-lastupdated: "2017-07-03"
+lastupdated: "2017-07-21"
 
 ---
 
@@ -37,10 +37,21 @@ This diagram shows the overall architecture of a complete solution:![Flow diagra
 
 ### Implementation
 
-You complete these steps to implement your application:
+Here's how you will implement your application:
 
-- **Configure a workspace.** With the easy-to-use graphical environment, you set up the dialog flow and training data for your application.
-- **Develop your application.** You code your application to connect to the {{site.data.keyword.conversationshort}} workspace through API calls. You then integrate your app with other systems that you need, including back-end systems and third-party services such as chat services or social media.
+- **Configure a workspace.** With the easy-to-use graphical environment, set up the training data and dialog for your application.
+
+    The training data consists of the following artifacts:
+    - Intents: Goals that you anticipate your users will have when they interact with the service. Define one intent for each goal that can be identified in a user's input. For example, you might define an intent named *store_hours* that answers questions about store hours. For each intent, you add sample utterances that reflect the input customers might use to ask for the information they need, such as, "What time do you open?"
+    - Entities: An entity represents a term or object that provides context for an intent. For example, an entity might be a city name that helps your dialog to distinguish which store the user wants to know store hours for.
+
+      As you add training data, a natural language classifier is automatically added to the workspace, and is trained to understand the types of requests that you have indicated the service should listen for and respond to.
+
+    Use the dialog tool to build a dialog flow that incorporates your intents and entities. The dialog flow is represented graphically in the tool as a tree. You can add a branch to process each of the intents that you want the service to handle. You can then add branch nodes that handle the many possible permutations of a request based on other factors, such as the entities found in the user input or information that is passed to the service from your application or another external service.
+
+    See [Configuring a Conversation workspace](configure-workspace.html) for more information.
+
+- **Deploy your workspace.** Deploy the configured workspace to users by connecting it to a front-end user interface, social media, or a messaging channel. See [Deploying](deploy.html) for details.
 
 ## Language support
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -47,57 +47,69 @@ Existing models that you have trained will not be immediately impacted, but expi
 The following new features and changes to the service are available.
 
 ### 19 July 2017
+{: #19July2017}
 
 - The {{site.data.keyword.conversationshort}} REST API now supports access to dialog nodes. For more information, see the [API Reference ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://www.ibm.com/watson/developercloud/conversation/api/v1/#dialog_nodes){: new_window}.
 
 ### 14 July 2017
+{: #14July2017}
 
 - The slots functionality of dialogs was enhanced. For example, a *slot_in_focus* property was added that you can use to define a condition that applies to a single slot only. See [Gathering information with slots](/docs/services/conversation/dialog-build.html#slots) for details.
 
 ### 12 July 2017
+{: #12July2017}
 
 - **Support for Czech** - Czech language support has been introduced; please see the [Supported languages](lang-support.html) topic for additional details.
 
 ### 11 July 2017
+{: #11July2017}
 
 - **Test in Slack** - You can use the new **Test in Slack** tool to quickly deploy your workspace as a Slack bot user for testing purposes. This tool is available only for the Bluemix US South region. For more information, see [Testing in Slack](test-deploy.html).
 
 - **Updates to Arabic** - Arabic language support has been enhanced to include absolute scoring per intent, and the ability to mark intents as irrelevant; please see the [Supported languages](lang-support.html) topic for additional details. Note that the {{site.data.keyword.conversationshort}} service learning models may have been updated as part of this enhancement, and when you retrain your model any changes will be applied; see [Updated models](release-notes.html#updated-models) for more information.
 
 ### 23 June 2017
+{: #23June2017}
 
 - **Updates to Korean** - Korean language support has been enhanced; please see the [Supported languages](lang-support.html) topic for additional details. Note that the {{site.data.keyword.conversationshort}} service learning models may have been updated as part of this enhancement, and when you retrain your model any changes will be applied; see [Updated models](release-notes.html#updated-models) for more information.
 
 ### 22 June 2017
+{: #22June2017}
 
 - **Introducing slots** - It is now easier to collect multiple pieces of information from a user in a single node by adding slots. Previously, you had to create several dialog nodes to cover all the possible combinations of ways that users might provide the information. With slots, you can configure a single node that saves any information that the user provides, and prompts for any required details that the user does not. See [Gathering information with slots](dialog-build.html#slots) for more details.
 - **Simplified dialog tree** - The dialog tree has been redesigned to improve its usability. The tree view is more compact so it is easier to see where you are within it. And the links between nodes are represented in a way that makes it easier to understand the relationships between the nodes.
 
 ### 21 June 2017
+{: #21June2017}
 
 - **Arabic support** - Language support for Arabic is now generally available. For details, see [Configuring bi-directional languages](lang-support.html#configuring-bi-directional).
 - **Language updates** - The {{site.data.keyword.conversationshort}} service algorithms have been updated to improve overall language support. See the [Supported languages](lang-support.html) topic for details.
 
 ### 16 June 2017
+{: #16June2017}
 
 - **Recommendations (Beta - Premium users only)** - The Improve panel also includes a **Recommendations** page that recommends ways to improve your system by analyzing the conversations that users have with your chatbot, and taking into account your system's current training data and response certainty.
 
 ### 14 June 2017
+{: #14June2017}
 
 - **Fuzzy matching for additional languages (Beta)** - Fuzzy matching for entities is now available for additional languages, as noted in the [Supported languages](lang-support.html) topic. You can turn on fuzzy matching per entity to improve the ability of the service to recognize terms in user input with syntax that is similar to the entity, without requiring an exact match. The feature is able to map user input to the appropriate corresponding entity despite the presence of misspellings or slight syntactical differences. For example, if you define giraffe as a synonym for an animal entity, and the user input contains the terms giraffes or girafe, the fuzzy match is able to map the term to the animal entity correctly. See [Fuzzy matching](entities.html#fuzzy-matching) for details.
 
 ### 13 June 2017
+{: #13June2017}
 
 - **User conversations** - The Improve panel now includes a **User conversations** page, which provides a list of user interactions with your chatbot that can be filtered by keyword, intent, entity, or number of days. You can open individual conversations to correct intents, or to add entity values or synonyms.
 - **Regex change** - The regular expressions that are supported by SpEL functions like find, matches, extract, replaceFirst, replaceAll and split have changed. A group of regular expression constructs are no longer allowed, including look-ahead, look-behind, possessive repetition and backreference constructs. This change was necessary to avoid a security exposure in the original regular expression library.
 
 ### 12 June 2017
+{: #12June2017}
 
 - The maximum number of workspaces that you can create with the **Lite** plan (formerly named the Free plan) changed from 3 to 5.
 - You can now assign any name to a dialog node; it does not need to be unique. And you can subsequently change the node name without impacting how the node is referenced internally. The name you specify is treated as an alias and the system uses its own internal identifier to reference the node.
 - You can no longer change the language of a workspace after you create it by editing the workspace details. If you need to change the language, you can export the workspace as a JSON file, update the language property, and then import the JSON file as a new workspace.
 
 ### 6 June 2017
+{: #6June2017}
 
 - **Learn** - A new *Learn about {{site.data.keyword.watson}} {{site.data.keyword.conversationshort}}* page is available that provides getting started information and links to service documentation and other useful resources. To open the page, click the ![i for information.](images/info.png) icon in the page header.
 - **Bulk export and delete** - You can now simultaneously export a number of intents or entities to a CSV file, so you can then import and reuse them for another {{site.data.keyword.conversationshort}} application. You can also simultaneously select a number of entities or intents for deletion in bulk.
@@ -108,16 +120,19 @@ The following new features and changes to the service are available.
 - **Reduced training time** - Multiple models are now trained in parallel, which noticeably reduces the training time for large workspaces.
 
 ### 26 May 2017
+{: #26May2017}
 
 - The current API version is now `2017-05-26`. This version introduces the following changes:
     - The schema of ErrorResponse objects has changed. This change affects all endpoints and methods. For more information, see the [API Reference ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://www.ibm.com/watson/developercloud/conversation/api/v1/){: new_window}.
     - The internal schema used to represent dialog nodes in exported workspace JSON has changed. If you use the `2017-05-26` API to import a workspace that was exported using an earlier version, some dialog nodes might not import correctly. For best results, always import a workspace using the same version that was used to export it.
 
 ### 25 May 2017
+{: #25May2017}
 
 - You can now manage context variables in the "Try it out" pane. Click the **Manage context** link to open a new pane where you can set and check the values of context variables as you test the dialog. See [Testing your dialog](dialog-test.html) for more information.
 
 ### 16 May 2017
+{: #16May2017}
 
 - A **Car Dashboard** sample workspace is now available when you open the tool. To use the sample as a starting point for your own workspace, edit the workspace. If you want to use it for multiple workspaces, then duplicate it instead. The sample workspace does not count toward your subscription workspace total unless you use it.
 - It is now easier to navigate the tool. The navigation menu options are available from the side of the main page instead of the top. At the top of the page, Breadcrumb links display that show you where you are. You can now switch between service instances from the Workspaces page. To get there quickly, click **Back to workspaces** from the navigation menu. If you have multiple service instances, the name of the current instance is displayed. You can click the **Change** link beside it to choose another instance.
@@ -127,6 +142,7 @@ The following new features and changes to the service are available.
 - An Overview page is available from the Improve tab. The page provides a summary of interactions with your bot. You can view the amount of traffic for a given time period, as well as the intents and entities that were recognized most often in user conversations. For additional information, see [Using the Overview page](logs_oview.html).
 
 ### 27 April 2017
+{: #27April2017}
 
 - The following system entities are now available as beta features in English only:
     - sys-location: Recognizes references to locations, such as towns, cities, and countries, in user utterances.
@@ -136,6 +152,7 @@ The following new features and changes to the service are available.
 - Fuzzy matching for entities is a beta feature that is now available in English. You can turn on fuzzy matching per entity to improve the ability of the service to recognize terms in user input with syntax that is similar to the entity, without requiring an exact match. The feature is able to map user input to the appropriate corresponding entity despite the presence of misspellings or slight syntactical differences. For examples, if you define **giraffe** as a synonym for an animal entity, and the user input contains the terms *giraffes* or *girafe*, the fuzzy match is able to map the term to the animal entity correctly. See [Defining entities](entities.html#fuzzy-matching) and search for "Fuzzy Matching" for details.
 
 ### 18 April 2017
+{: #18April2017}
 
 - The {{site.data.keyword.conversationshort}} REST API now supports access to the following resources:
     - entities
@@ -153,6 +170,7 @@ The following new features and changes to the service are available.
 - A new Credentials tab provides a single place where you can find all of the information you need for connecting your application to a workspace (such as the service credentials and workspace ID), as well as other deployment options. To access the Credentials tab for your workspace, click the ![Menu](images/Menu_16.png) icon and select **Credentials**.
 
 ### 9 March 2017
+{: #9March2017}
 
 The {{site.data.keyword.conversationshort}} REST API now supports access to the following resources:
 
@@ -164,6 +182,7 @@ The {{site.data.keyword.conversationshort}} REST API now supports access to the 
 For more information, see the [API Reference ![External link icon](../../icons/launch-glyph.svg "External link icon")](https://www.ibm.com/watson/developercloud/conversation/api/v1/){: new_window}.
 
 ### 7 March 2017
+{: #7March2017}
 
 - The use of `.` or `..` as an intent name causes problems and is no longer supported.
 
@@ -172,14 +191,17 @@ For more information, see the [API Reference ![External link icon](../../icons/l
     Paying customers can contact support for a database change.
 
 ### 1 March 2017
+{: #1March2017}
 
 - System entities are now enabled in German.
 
 ### 22 February 2017
+{: #22February2017}
 
 - Messages are now limited to 2,048 characters.
 
 ### 3 February 2017
+{: #3February2017}
 
 - In this release, we change how intents are scored and add the ability to mark input as irrelevant to your application. [For details, see Defining intents](intents.html#mark-irrelevant) and search for "Mark as irrelevant".
     - These features are available in the tooling by [upgrading your workspace](upgrading.html).
@@ -189,14 +211,17 @@ For more information, see the [API Reference ![External link icon](../../icons/l
     See [Jump to actions](dialog-build.html#jump-to) for details.
 
 ### 11 January 2017
+{: #11January2017}
 
 - In this release, you can customize node titles in dialog.
 
 ### 22 December 2016
+{: #22December2016}
 
 - In this release, dialog nodes display a new section for `node title`. The ability to customize the `node title` is not available. When collapsed, the `node title` displays the `node condition` of the dialog node. If there is not a `node condition`, "Untitled Node" is displayed as the title.
 
 ### 19 December 2016
+{: #19December2016}
 
 Several changes make the dialog builder easier and more intuitive to use:
 
@@ -204,17 +229,20 @@ Several changes make the dialog builder easier and more intuitive to use:
 - A node can contain multiple responses, each triggered by a separate condition. For more information see [Multiple responses](dialog-build.html#responses).
 
 ### 5 December 2016
+{: #5December2016}
 
 - New languages are supported, all in Experimental mode: German, Traditional Chinese, Simplified Chinese, and Dutch.
 - Two new system entities are available: @sys-date and @sys-time. For details, see [System entities](system-entities.html).
 
 ### 21 October 2016
+{: #21October2016}
 
 - The {{site.data.keyword.conversationshort}} service now provides system entities, which are common entities that can be used across any use case. For details, see [Defining entities](entities.html) and search for "Enabling system entities".
 - You can now view a history of conversations with users on the Improve page. You can use this to understand your bot's behavior. For details, see [Improving understanding](logs.html).
 - You can now import entities from a comma-separated value (CSV) file, which helps with when you have a large number of entities. For details, see [Defining entities](entities.html) and search for "Importing entities".
 
 ### 20 September 2016
+{: #20September2016}
 
 **New version**: 2016-09-20
 
@@ -223,15 +251,18 @@ To take advantage of the changes in a new version, change the value of the `vers
 - version **2016-09-20**: `dialog_stack` changed from an array of strings to an array of JSON objects.
 
 ### 29 August 2016
+{: #29August2016}
 
 - You can move dialog nodes from one branch to another, as siblings or peers. For details, see [Building a dialog](dialog-build.html) and search for "Moving a dialog node".
 - You can expand the JSON editor window.
 - You can view chat logs of your bot's conversations to help you understand it's behavior. You can filter by intents, entities, date, and time. For details, see [Improving understanding](logs.html)
 
 ### 11 July 2016
+{: #21July2016}
 
 - This General Availability release enables you to work with entities and dialogs to create a fully functioning bot.
 
 ### 18 May 2016
+{: #18May2016}
 
 - This Experimental release of the {{site.data.keyword.conversationshort}} introduces the user interface and enables you to work with workspaces, intents, and examples.

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,7 +2,7 @@
 
 copyright:
   years: 2015, 2017
-lastupdated: "2017-07-19
+lastupdated: "2017-07-19"
 
 ---
 


### PR DESCRIPTION
Made the following changes:
- Per Andy s request, added ids to individual date entries in relnotes topic.
- Made updates to Building a dialog topic based on feedback from dev team (tomas, jan)
- Added content to the implementation section of About topic to address https://github.ibm.com/watson-engagement-advisor/wea-backlog/issues/8766.
- Make a fix to the getting started - Pat C noticed it still referenced the conversation_start node.
